### PR TITLE
Use docker `exec` instead of `run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ When attached this way you can edit your configuration file from your host machi
 If you change your custom configuration, you can reload Kong (without downtime) by issuing:
 
 ```shell
-$ docker run -it kong kong reload
+$ docker exec -it kong kong reload
 ```
 
 This will run the [`kong reload`][kong-docs-reload] command in your container.


### PR DESCRIPTION
`exec` is for running commands inside the existing container, `run` would actually create a new container and run the `kong reload` there ... which likely will fail like this:
~~~~
$ docker run -it kong kong reload
Unable to find image 'kong:latest' locally
Trying to pull repository docker.io/kong ... not found
Error: image library/kong:latest not found
$ docker run -it mashape/kong kong reload
[INFO] Using configuration: /etc/kong/kong.yml
[ERR] Could not reload: Kong is not running.
~~~~

(The first error would be because `run` wants an image name, not a container name; the second one then uses a suitable image name, but that one just doesn't have a kong running)