### PR TITLE
squash yum installs and cleanup into single docker layer to save 76mb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER Marco Palladino, marco@mashape.com
 
 ENV KONG_VERSION 0.8.1
 
-RUN yum install -y epel-release
-RUN yum install -y https://github.com/Mashape/kong/releases/download/$KONG_VERSION/kong-$KONG_VERSION.el7.noarch.rpm && \
+RUN yum install -y epel-release && \
+    yum install -y https://github.com/Mashape/kong/releases/download/$KONG_VERSION/kong-$KONG_VERSION.el7.noarch.rpm && \
     yum clean all
 
 VOLUME ["/etc/kong/"]


### PR DESCRIPTION
Minor space saving enhancement:

REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
kong-layer                 latest              b009abd6c8e3        8 minutes ago       312.6 MB
kong                       latest              fd42b66f6122        17 minutes ago      388.8 MB