### PR TITLE
Fix proposal for issue #1164

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,4 +6,10 @@ if [ -n "$DATABASE" ]; then
   echo -e '\ndatabase: "'$DATABASE'"' >> /etc/kong/kong.yml
 fi
 
+# Make sure kong processes won't be considered as running because of pid file
+if [ $( ls -1 /usr/local/kong/*pid | wc -l ) -gt 0 ]
+then
+  rm /usr/local/kong/*pid
+fi
+
 exec "$@"


### PR DESCRIPTION
Sometimes Kong can't start after stoping a docker container without invoking
the kong stop command. The error message is "[ERR] dnsmasq is already running".
Since the container has been stopped, all processes in that container has been
stopped as well.

My idea is that the BaseService:is_running() method
https://github.com/Mashape/kong/blob/0.8.3/kong/cli/services/base_service.lua#L56
may not work well. It runs 'kill -0' on the pid contained in the
/usr/local/kong/*pid files which is a good idea to check if a pid exists
as a process but it does not check that the process is the expected
process. In other words, the pid contained in the dnsmasq.pid file can match
an existing process which is a totally different process than a dnsmasq one.

Furthermore, in a docker container these pids belongs to the previous launch
of the container.
The fix I suggest is to remove all the pid files contained in
/usr/local/kong before running the kong start command.
