### PR TITLE
Fix proposal for issue #1074

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,13 @@ RUN yum install -y https://github.com/Mashape/kong/releases/download/$KONG_VERSI
 
 COPY config.docker/kong.yml /etc/kong/
 
+# Add Tini
+ENV TINI_VERSION v0.10.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/tini", "--", "/docker-entrypoint.sh"]
 
 EXPOSE 8000 8443 8001 7946
 CMD ["kong", "start"]


### PR DESCRIPTION
There are a lot of serf defunct process while running kong in a docker
container.
A docker container is meant to run only one process. But the kong start
command runs serf, dnsmasq and many other processes. All these process pid's
don't have a parent and they become a zombie process when they are
finished.
The fix for this is to use a lite init system such as tini, or dumb-init.

Here is a fix proposal using tini.