### PR TITLE
Ensure Kong logs reach docker logging v0.10.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,11 @@ RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+# ensure Kong logs go to the log pipe from our entrypoint and so to docker logging
+RUN mkdir -p /usr/local/kong/logs \
+    && ln -sf /tmp/logpipe /usr/local/kong/logs/access.log \
+    && ln -sf /tmp/logpipe /usr/local/kong/logs/serf.log \
+    && ln -sf /tmp/logpipe /usr/local/kong/logs/error.log
+
 EXPOSE 8000 8443 8001 7946
 CMD ["kong", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 # ensure Kong logs go to the log pipe from our entrypoint and so to docker logging
 RUN mkdir -p /usr/local/kong/logs \
     && ln -sf /tmp/logpipe /usr/local/kong/logs/access.log \
+    && ln -sf /tmp/logpipe /usr/local/kong/logs/admin_access.log \
     && ln -sf /tmp/logpipe /usr/local/kong/logs/serf.log \
     && ln -sf /tmp/logpipe /usr/local/kong/logs/error.log
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,15 @@
 #!/usr/local/bin/dumb-init /bin/bash
 set -e
 
+# Make a pipe for the logs so we can ensure Kong logs get directed to docker logging
+# see https://github.com/docker/docker/issues/6880
+# also, https://github.com/docker/docker/issues/31106, https://github.com/docker/docker/issues/31243
+# https://github.com/docker/docker/pull/16468, https://github.com/behance/docker-nginx/pull/51
+rm -f /tmp/logpipe
+mkfifo -m 666 /tmp/logpipe
+# This child process will still receive signals as per https://github.com/Yelp/dumb-init#session-behavior
+cat <> /tmp/logpipe 1>&2 &
+
 # Disabling nginx daemon mode
 export KONG_NGINX_DAEMON="off"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,8 @@ mkfifo -m 666 /tmp/logpipe
 # This child process will still receive signals as per https://github.com/Yelp/dumb-init#session-behavior
 cat <> /tmp/logpipe 1>&2 &
 
+# NOTE, to configure the `File Log` plugin to route logs to Docker logging, direct `config.path` at `/tmp/logpipe`
+
 # Disabling nginx daemon mode
 export KONG_NGINX_DAEMON="off"
 


### PR DESCRIPTION
Goes some way towards https://github.com/Mashape/docker-kong/issues/40 and https://github.com/Mashape/docker-kong/issues/55, at least short term. It's a bit hacky so it may be the case of waiting for Docker to resolve the below related issues. In the meantime this can help gain visibility of the Kong logs and I've seen several other projects work around the same issues.

I've tested this locally so far using Docker for Mac and also on a Kubernetes cluster based on CoreOS Container Linux, both working well it seems.

Several related issues such as https://github.com/docker/docker/issues/6880, https://github.com/docker/docker/issues/31106, https://github.com/docker/docker/issues/31243. 

For anyone interested I've pushed this to https://hub.docker.com/r/cknowles/kong/ as well.