### PR TITLE
Add Docker Healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,11 @@ RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+# The first kong container will have to run migrations on the database, so it will
+# take a while for the port 8000 to be reachable. --start-period will help us delay
+# the healthcheck failure
+HEALTHCHECK --interval=5s --retries=10 --start-period=180s \
+    CMD curl -I -s -L http://127.0.0.1:8000 || exit 1
+
 EXPOSE 8000 8443 8001 7946
 CMD ["kong", "start"]


### PR DESCRIPTION
Add Docker Healthcheck to prevent connexion refused when scaling up Kong containers in a Docker swarm service.