### PR TITLE
fix: use postgres user for kong-database healthcheck

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - POSTGRES_USER=kong
       - POSTGRES_DB=kong
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This following recurring log was a hint that some recurrent task would not use
an existing PostgreSQL user:

    kong-database_1   | FATAL:  role "root" does not exist

The proposed fix ensures `healthcheck` is always using the default
`postgres` user instead of `$(whoami)`.

We switch `CMD-SHELL` to `CMD` so we can pass arguments to `pg_isready`
in subsequent elements of the Array.

It seems the shell does not inherit the environment variables passed to
the `environment` attribute, so using `$POSTGRES_USER` did not work in
my initial tests.